### PR TITLE
SongList: reworked search logic

### DIFF
--- a/include/FilterOptions.hpp
+++ b/include/FilterOptions.hpp
@@ -104,6 +104,7 @@ public:
 };
 
 enum class SortMode {
+    Relevance,
     Newest,
     Oldest,
     Latest_Ranked,

--- a/include/UI/ViewControllers/SongList.hpp
+++ b/include/UI/ViewControllers/SongList.hpp
@@ -71,7 +71,7 @@ namespace BetterSongSearch::UI {
         inline static std::vector<const SongDetailsCache::Song*> sortedSongList;
 
         // State variables to be globally accessible
-        inline static SortMode currentSort = SortMode::Newest;
+        inline static SortMode currentSort = SortMode::Relevance;
         inline static std::string currentSearch = "";
 
         inline static std::unordered_set<std::string> songsWithScores;
@@ -214,7 +214,7 @@ DECLARE_CLASS_CODEGEN_INTERFACES(BetterSongSearch::UI::ViewControllers, SongList
     DECLARE_INSTANCE_FIELD(UnityEngine::UI::Button*, downloadButton);
     DECLARE_INSTANCE_FIELD(UnityEngine::UI::Button*, playButton);
     DECLARE_INSTANCE_FIELD(UnityEngine::UI::Button*, infoButton);
-    BSML_OPTIONS_LIST_OBJECT(sortModeSelections, "Newest", "Oldest", "Latest Ranked", "Most Stars", "Least Stars", "Best rated", "Worst rated");
+    BSML_OPTIONS_LIST_OBJECT(sortModeSelections, "Relevance", "Newest", "Oldest", "Latest Ranked", "Most Stars", "Least Stars", "Best rated", "Worst rated");
 
     DECLARE_INSTANCE_FIELD(BSML::DropdownListSetting*, sortDropdown);
     DECLARE_INSTANCE_FIELD(StringW, selectedSortMode);


### PR DESCRIPTION
Firstly, thank you for the fantastic mod!

I'm not proficient in C++, and I'm an absolute noob in quest mod development, but here's my attempt to enhance the search functionality. Currently, it performs poorly and most of the time it is nearly impossible to find songs by artists or by song name, in my opinion. Also, from time to time, there are some random results at the top.

I checked the algorithm and was a bit surprised with a woogabooga logic. The scoring was calculated based on some questionable conditions. Additionally, I believe sorting shouldn't impact the scoring at all; it should only reorder entries that were filtered previously (by ignoring any scores retrieved before). 

Better song search for the `BetterSongSearchQuest`!

So, here are the changes I made:
- introduced a new prefix-based search algorithm with a super simple scoring logic. Ideally it should be bm25 or tfidf (and maybe Trie for prefix search), but it is enough for now to go with a simple logic (IMHO)
- if there are multiple words in your query, then it is treated as an `AND` operation over multiple prefix searches
- added a `Relevance` sorting option (default) that currently uses scores (weights), but later on, it could be improved by including extra weights based on other properties (for example, rating might slightly affect the score).
- reworked how sorting options work: no more extra sorting weights; it now reorders the matches according to the sorting options.

I understand that this is a port of the desktop mod version, and I'm not sure if it's okay to change the logic to be completely different from how it was implemented there.

Anyway, please try the new logic locally and let me know if it really works better than before or not (at least now I can find songs 😄)

fixes https://github.com/bsq-ports/BetterSongSearchQuest/issues/17

offtop:
I'm facing an issue with the `./copy.ps1` script on windows (quest3):
```
adb: error: failed to copy 'build/libBetterSongSearch.so' to '/sdcard/Android/data/com.beatgames.beatsaber/files/mods/libBetterSongSearch.so': remote fchown failed: Operation not permitted
build/libBetterSongSearch.so: 1 file pushed, 0 skipped. 136.2 MB/s (8060032 bytes in 0.056s)
Starting: Intent { act=android.intent.action.MAIN cat=[android.intent.category.LAUNCHER] cmp=com.beatgames.beatsaber/com.unity3d.player.UnityPlayerActivity }
Starting: Intent { act=android.intent.action.MAIN cat=[android.intent.category.LAUNCHER] cmp=com.beatgames.beatsaber/com.unity3d.player.UnityPlayerActivity }
Warning: Activity not started, intent has been delivered to currently running top-most instance.
```
Maybe you know how to resolve the issue with the failed copy operation? The mod is disabled after this. Instead of this, I am currently building the qmod file and patching via QuestPatcher.